### PR TITLE
carrerwaveによる複数画像upload機能を実装。

### DIFF
--- a/app/assets/stylesheets/modules/_products_new.scss
+++ b/app/assets/stylesheets/modules/_products_new.scss
@@ -53,6 +53,7 @@
                             float: right;
                             position: relative;
                             width: 538px;
+                            // width: 50px;
                             margin: 0;
                             min-height: 102px;
                             padding: 40px;
@@ -68,8 +69,11 @@
                                 right: 16px;
                               }
                       }
+                      .have-item {
+                        margin: 0 0 0 20px;
+                      }
                       .file {
-                        display: none;
+                        // display: none;
                       }
                   }
                   .clearfix:after {

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -6,7 +6,7 @@ class ProductsController < ApplicationController
 
   def new
     @product = Product.new
-    4.times { @product.product_images.build }
+    4.times { @product.product_images.build}
   end
 
   def show
@@ -14,7 +14,8 @@ class ProductsController < ApplicationController
   end
 
   def create
-     @product = Product.new(product_params)
+    @product = Product.new(product_params)
+
     if @product.save
       redirect_to root_path(@product)
     else

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -31,7 +31,6 @@ class ProductsController < ApplicationController
 
   private
   def product_params
-    binding.pry
     params.require(:product).permit(:name, :detail, :price, :category_id, :size_id, :area_id, product_images_attributes: [:image]).merge(:seller => 1, :condition => 1, :shipmentday => 1)
   end
 end

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -16,31 +16,13 @@
                 .sell-upload-items-container
                   .sell-upload-items.have-item-0
                     %ul
-                  = f.fields_for :product_images do |i|
-                    = i.label :image, class: "sell-upload-drop-box", for: "image" do
-                      %pre.visible-pc
-                        :preserve
-                          ドラッグアンドドロップ
-                          またはクリックしてファイルをアップロード
-                      = i.file_field :image, class: "file", id: "image", multiple: true
-                    / = i.label :image, class: "sell-upload-drop-box", for: "image" do
-                    /   %pre.visible-pc
-                    /     :preserve
-                    /       ドラッグアンドドロップ
-                    /       またはクリックしてファイルをアップロード
-                    /   = i.file_field :image, class: "file", id: "image", multiple: true
-                    / = i.label :image, class: "sell-upload-drop-box", for: "image" do
-                    /   %pre.visible-pc
-                    /     :preserve
-                    /       ドラッグアンドドロップ
-                    /       またはクリックしてファイルをアップロード
-                    /   = i.file_field :image, class: "file", id: "image", multiple: true
-                    / = i.label :image, class: "sell-upload-drop-box", for: "image" do
-                    /   %pre.visible-pc
-                    /     :preserve
-                    /       ドラッグアンドドロップ
-                    /       またはクリックしてファイルをアップロード
-                    /   = i.file_field :image, class: "file", id: "image", multiple: true
+                = f.fields_for :product_images do |fi|
+                  .sell-upload-drop-box.have-item
+                    %pre.visible-pc
+                      :preserve
+                        ドラッグアンドドロップ
+                        またはクリックしてファイルをアップロード
+                    = fi.file_field :image, class: "file"
             .sell-content
               .form-group
                 = f.label :name do
@@ -91,7 +73,7 @@
                 /     %input.input-default{:placeholder => "例）シャネル", :value => ""}/
                 /     %div
                 .form-group
-                  %label
+                  = f.label :condition do
                     商品の状態
                     %span.form-require 必須
                   .select-wrap
@@ -143,7 +125,7 @@
                     = f.collection_select :area_id, Area.all, :id, :name, {:include_blank => "---"}, {class: "select-default"}
                     %i.fas.fa-chevron-down
                 .form-group
-                  %label
+                  = f.label :shipmentday do
                     発送までの日数
                     %span.form-require 必須
                   .select-wrap

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -16,13 +16,13 @@
                 .sell-upload-items-container
                   .sell-upload-items.have-item-0
                     %ul
-                = f.fields_for :product_images do |fi|
+                = f.fields_for :product_images do |i|
                   .sell-upload-drop-box.have-item
                     %pre.visible-pc
                       :preserve
                         ドラッグアンドドロップ
                         またはクリックしてファイルをアップロード
-                    = fi.file_field :image, class: "file"
+                    = i.file_field :image, class: "file"
             .sell-content
               .form-group
                 = f.label :name do


### PR DESCRIPTION
# WHAT
carrerwaveによる複数画像upload機能を実装。

# WHY
carrewaveを使った
複数画像のアップロードを実現。
Varidationは次のタスクで
設定するためにまだ実装していません。
・product.rb
  has_many :product_images, dependent: :destroy
  accepts_nested_attributes_for :product_images
・product_images.rb
  belongs_to :product, optional: true
  mount_uploader :image, ImageUploader
はすでに実装済みです。

ストロングパラメーター
private
  def product_params
    params.require(:product).permit(:name, :detail, :price, :category_id, :size_id, :area_id, product_images_attributes: [:image]).merge(:seller => 1, :condition => 1, :shipmentday => 1)
  end

画像アップロード機能を先に実装するために、
出品者のIDなどはベタ打ちでmergeする形にしています。
そこは次のタスクで実装予定です。