### PR TITLE
商品出品時に取引情報テーブルに商品IDを入れる機能を実装。

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -28,6 +28,7 @@ class ProductsController < ApplicationController
     @product = Product.new(product_params)
 
     if @product.save
+      Trade.create(product_id: @product.id)
       redirect_to root_path(@product)
     else
       render :action => "new"


### PR DESCRIPTION
# WHAT
商品購入時に取引テーブルに出品した商品のIDが
保存できるように修正。

# WHY
取引情報をつくるため。