### PR TITLE
ユーザーのプロフィール画像の変更機能

### DIFF
--- a/app/assets/stylesheets/modules/_user_mypage.scss
+++ b/app/assets/stylesheets/modules/_user_mypage.scss
@@ -33,13 +33,22 @@
     left: 0;
     right : 0;
     transform: translate(0, -50%);
+    .form-wrapper{
+      margin-top: 3px;
+    }
     figure {
       overflow: hidden;
-      width : 60px;
-      height : 60px;
+      width : 65px;
+      height : 65px;
       margin : 0 auto;
-      border-radius : 50%;
-      display : block;
+      //border-radius : 50%;
+      display : inline-block;
+      .profile-image{
+        width: 65px;
+        height: 65px;
+        overflow: hidden;
+        border-radius: 50%;
+      }
       img {
         vertical-align: middle;
         }
@@ -273,6 +282,10 @@ h2{
   }
 }
 
+#profile_img{
+  display: none;
+}
+
 .angle-right {
   position: absolute;
   top: 23px;
@@ -283,4 +296,8 @@ h2{
 
 a{
   text-decoration: none;
+}
+
+#profile_img_change {
+  opacity: 0.6;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,7 +35,7 @@ class ApplicationController < ActionController::Base
   end
 
   def configure_permitted_parameter
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :point])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :point, :image])
     devise_parameter_sanitizer.permit(:account_update, keys: [:name])
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@ class UsersController < ApplicationController
   require 'payjp'
 
   before_action :set_category
+  before_action :set_user, only: [:update]
   protect_from_forgery except: :pay
 
   def index
@@ -35,6 +36,10 @@ class UsersController < ApplicationController
     else
       redirect_to register_cregit_card_path
     end
+  end
+
+  def set_user
+    @user = User.find(params[:id])
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,6 @@ class UsersController < ApplicationController
   end
 
   def update
-    @user = User.find(params[:id])
     if @user.id == current_user.id
       current_user.update(update_user_profile)
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,6 @@ class UsersController < ApplicationController
   protect_from_forgery except: :pay
 
   def index
-    @user = current_user
   end
 
   def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,12 @@ class UsersController < ApplicationController
   protect_from_forgery except: :pay
 
   def index
+    @user = current_user
+  end
+
+  def update
+    current_user.update(update_user_profile)
+    redirect_to users_path
   end
 
   def register_cregit_card
@@ -24,6 +30,11 @@ class UsersController < ApplicationController
     else
       redirect_to register_cregit_card_path
     end
+  end
+
+  private
+  def update_user_profile
+    params.require(:user).permit(:image)
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,8 +12,6 @@ class UsersController < ApplicationController
   def update
     if @user.id == current_user.id
       current_user.update(update_user_profile)
-    else
-      redirect_to users_path
     end
     redirect_to users_path
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,12 @@ class UsersController < ApplicationController
   end
 
   def update
-    current_user.update(update_user_profile)
+    @user = User.find(params[:id])
+    if @user.id == current_user.id
+      current_user.update(update_user_profile)
+    else
+      redirect_to users_path
+    end
     redirect_to users_path
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
   has_many :trades
   has_many :likes,dependent: :destroy
   has_many :liked_products, through: :likes, source: :product
+  mount_uploader :image, ImageUploader
 
   def already_liked?(product)
     likes.exists?(product_id: product.id)

--- a/app/views/products/_header.html.haml
+++ b/app/views/products/_header.html.haml
@@ -15,7 +15,6 @@
             %h2
               = link_to category_index_path ,class: "pc-header-nav-foot" do
                 カテゴリーから探す
-
             %ul.pc-header-nav-parent-wrap
               - @categoryroot.each do |root|
                 %li.pc-header-nav-parent
@@ -36,19 +35,6 @@
                 %h3
                   = link_to category_index_path do
                     カテゴリー一覧
-
-
-
-
-
-
-
-
-
-
-
-
-
           %li
             %h2
               %a.pc-header-nav-root{href: ""} ブランドから探す

--- a/app/views/users/_user_icon.html.haml
+++ b/app/views/users/_user_icon.html.haml
@@ -2,15 +2,16 @@
   = link_to "#" do
     %figure
       = image_tag("#{@user.image}", class: "profile-image")
-    .form-wrapper
-      = form_for @user do |f|
-        %label{for: 'profile_img'}
-          = fa_icon 'images'
-          = f.file_field :image, class: "profile-image-change", id: "profile_img"
-          = f.button type: "submit", id: "profile_img_change" do
-            = fa_icon "angle-up"
+    - if current_user.id == @user.id
+      .form-wrapper
+        = form_for @user do |f|
+          %label{for: 'profile_img'}
+            = fa_icon 'images'
+            = f.file_field :image, class: "profile-image-change", id: "profile_img"
+            = f.button type: "submit", id: "profile_img_change" do
+              = fa_icon "angle-up"
     %h2.bold
-      = current_user.name
+      = @user.name
     .mypage-number
       %div
         評価

--- a/app/views/users/_user_icon.html.haml
+++ b/app/views/users/_user_icon.html.haml
@@ -1,7 +1,14 @@
 %section.mypage-user-icon
   = link_to "#" do
     %figure
-      %img
+      = image_tag("#{@user.image}", class: "profile-image")
+    .form-wrapper
+      = form_for @user do |f|
+        %label{for: 'profile_img'}
+          = fa_icon 'images'
+          = f.file_field :image, class: "profile-image-change", id: "profile_img"
+          = f.button type: "submit", id: "profile_img_change" do
+            = fa_icon "angle-up"
     %h2.bold
       = current_user.name
     .mypage-number

--- a/app/views/users/_user_icon.html.haml
+++ b/app/views/users/_user_icon.html.haml
@@ -1,6 +1,7 @@
 %section.mypage-user-icon
   = link_to "#" do
     %figure
+    - if @user.image?
       = image_tag("#{@user.image}", class: "profile-image")
     - if current_user.id == @user.id
       .form-wrapper

--- a/app/views/users/_user_icon.html.haml
+++ b/app/views/users/_user_icon.html.haml
@@ -1,18 +1,17 @@
 %section.mypage-user-icon
   = link_to "#" do
     %figure
-    - if @user.image?
-      = image_tag("#{@user.image}", class: "profile-image")
-    - if current_user.id == @user.id
+    - if current_user.image?
+      = image_tag("#{current_user.image}", class: "profile-image")
       .form-wrapper
-        = form_for @user do |f|
-          %label{for: 'profile_img'}
+        = form_for current_user do |f|
+          = f.label :profile_img do
             = fa_icon 'images'
             = f.file_field :image, class: "profile-image-change", id: "profile_img"
             = f.button type: "submit", id: "profile_img_change" do
               = fa_icon "angle-up"
     %h2.bold
-      = @user.name
+      = current_user.name
     .mypage-number
       %div
         評価

--- a/db/migrate/20190118033307_add_image_to_users.rb
+++ b/db/migrate/20190118033307_add_image_to_users.rb
@@ -1,0 +1,5 @@
+class AddImageToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190118025036) do
+ActiveRecord::Schema.define(version: 20190118033307) do
 
   create_table "addresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id"
@@ -53,6 +53,11 @@ ActiveRecord::Schema.define(version: 20190118025036) do
     t.index ["product_id", "user_id"], name: "index_likes_on_product_id_and_user_id", unique: true, using: :btree
     t.index ["product_id"], name: "index_likes_on_product_id", using: :btree
     t.index ["user_id"], name: "index_likes_on_user_id", using: :btree
+  end
+
+  create_table "mypayjps", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "product_images", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -113,6 +118,13 @@ ActiveRecord::Schema.define(version: 20190118025036) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "tradeinfos", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "product_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_tradeinfos_on_product_id", using: :btree
+  end
+
   create_table "trades", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "product_id",                 null: false
     t.integer  "user_id"
@@ -137,6 +149,7 @@ ActiveRecord::Schema.define(version: 20190118025036) do
     t.integer  "point"
     t.string   "provider"
     t.string   "uid"
+    t.string   "image"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
@@ -151,6 +164,7 @@ ActiveRecord::Schema.define(version: 20190118025036) do
   add_foreign_key "products", "users", column: "seller"
   add_foreign_key "shipments", "shipingfees"
   add_foreign_key "sizes", "sizetypes"
+  add_foreign_key "tradeinfos", "products"
   add_foreign_key "trades", "products"
   add_foreign_key "trades", "users"
 end


### PR DESCRIPTION
# WHAT
ユーザーがマイページから自分のプロフィール画像を変更することができなかったため、
変更する機能を実装。
マイページからファイルアイコンを選択して矢印のボタンを押すと画像が変更できる。

# WHY
本家のメルカリがウェブ版では画像の変更ができないため。
ユーザビリティの向上のため。