### PR TITLE
出品者と出品者以外での商品詳細ページのビューを変更

### DIFF
--- a/app/controllers/mypayjp_controller.rb
+++ b/app/controllers/mypayjp_controller.rb
@@ -6,6 +6,9 @@ class MypayjpController < ApplicationController
 require 'payjp'
 
   def show
+    if current_user.id == @product.seller
+      redirect_to prouct_path
+    end
     @user = current_user
     @area = Area.find_by(id: current_user.address.prefecture)
     @product_images = ProductImage.find_by(product_id: params[:id])

--- a/app/controllers/mypayjp_controller.rb
+++ b/app/controllers/mypayjp_controller.rb
@@ -7,7 +7,7 @@ require 'payjp'
 
   def show
     if current_user.id == @product.seller
-      redirect_to prouct_path
+      redirect_to product_path
     end
     @user = current_user
     @area = Area.find_by(id: current_user.address.prefecture)

--- a/app/views/products/_header.html.haml
+++ b/app/views/products/_header.html.haml
@@ -52,7 +52,7 @@
         .l-right2
           %ul.pc-header-login-nav
             %li
-              = link_to new_user_session, class: "sp-header-btn btn-red" do
+              = link_to new_user_session_path, class: "sp-header-btn btn-red" do
                 ログイン
             %li
               = link_to new_user_path, class: "sp-header-btn header-signup" do

--- a/app/views/products/_header.html.haml
+++ b/app/views/products/_header.html.haml
@@ -43,7 +43,7 @@
         .l-right2
           %ul.pc-header-user-nav
             %li
-              = link_to new_user_session class: "pc-header-nav-root" do
+              = link_to users_path, class: "pc-header-nav-root" do
                 マイページ
             %li
               = link_to destroy_user_session_path, method: :delete,class: "pc-header-logout" do
@@ -52,7 +52,7 @@
         .l-right2
           %ul.pc-header-login-nav
             %li
-              = link_to users_path, class: "sp-header-btn btn-red" do
+              = link_to new_user_session, class: "sp-header-btn btn-red" do
                 ログイン
             %li
               = link_to new_user_path, class: "sp-header-btn header-signup" do

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -11,7 +11,7 @@
               - @product.product_images.each do |image|
                 .owl-item
                   .owl-item-inner
-                    = image_tag(src="#{image.image_url}", class: "owl-lazy")
+                    = image_tag("#{image.image_url}", class: "owl-lazy")
         .owl-nav.disable
           .owl-prev
           .owl-next

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -11,7 +11,7 @@
               - @product.product_images.each do |image|
                 .owl-item
                   .owl-item-inner
-                    %img.owl-lazy(src="#{image.image_url}")
+                    = image_tag(src="#{image.image_url}", class: "owl-lazy")
         .owl-nav.disable
           .owl-prev
           .owl-next
@@ -26,7 +26,7 @@
             出品者
           %td
             =link_to "#" do
-              = @product.user.id
+              = @product.user.name
             %div
               %div.item-user-ratings
                 %i.fas.fa-smile
@@ -100,7 +100,7 @@
       (税込)
     %span.item-shipping-fee
       送料込み
-  - if @product.trade.deal == false
+  - if @product.trade.deal == false && @product.seller != current_user.id
     = link_to product_mypayjp_path(@product), class: "item-buy-btn" do
       商品を購入する
   - elsif @product.trade.deal == true
@@ -120,25 +120,26 @@
           %i.far.fa-flag
           %span 不適切な商品の報告
     .item-button-right
-      %a(href='#')
+      = link_to "#" do
         %i.fas.fa-lock
         %span あんしん・あんぜんへの取り組み
-.listing-item-change-box
-  = link_to "商品の編集", edit_product_path ,class: "btn-default btn-red"
-  %p.text-center
-    or
-  = form_for @product , method: :delete do |f|
-    %button.btn-default.btn-red(type= "submit")
-      出品を再開する
-    = f.submit 'この商品を消去する', class: "btn-default btn-gray"
-%ul.nav-item-link-prev-next.clearfix
-  %li.nav-item-link-prev
-    = link_to "#" do
-      %i.fas.fa-chevron-left
-      商品名
-  %li.nav-item-link-next
-    = link_to "#" do
-      商品名
+- if user_signed_in? && @product.seller == current_user.id
+  .listing-item-change-box
+    = link_to "商品の編集", edit_product_path ,class: "btn-default btn-red"
+    %p.text-center
+      or
+    = form_for @product , method: :delete do |f|
+      %button.btn-default.btn-red(type= "submit")
+        出品を再開する
+      = f.submit 'この商品を消去する', class: "btn-default btn-gray"
+  %ul.nav-item-link-prev-next.clearfix
+    %li.nav-item-link-prev
+      = link_to "#" do
+        %i.fas.fa-chevron-left
+        商品名
+    %li.nav-item-link-next
+      = link_to "#" do
+        商品名
       %i.fas.fa-chevron-right
 .item-social-media-box
   .text-center


### PR DESCRIPTION
# What
・出品者が商品詳細ページを閲覧すると編集ボタンと削除ボタンを表示させ、購入ボタンを消す。
・それ以外が詳細ページを閲覧すると購入ボタンのみを表示させる。
・もし出品者が意図的に購入ページにリンクしようとした際は商品詳細ページにリダイレクトをかける。

# Why
サービスの実装に必要なため。