### PR TITLE
商品詳細画面にユーザーの商品一覧を表示させる。

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,7 +6,7 @@
 @import "modules/main";
 @import "modules/footer";
 @import "modules/user_mypage";
-@import "modules/productshow";
+@import "modules/product_show";
 @import "modules/exhibition";
 @import "modules/buy_product";
 @import "modules/userlogout";

--- a/app/assets/stylesheets/modules/_product_show.scss
+++ b/app/assets/stylesheets/modules/_product_show.scss
@@ -5,7 +5,6 @@
   width: 700px;
   padding: 24px 40px 40px;
   box-sizing: border-box;
-
     .item-name{
       font-size: 24px;
       text-align: center;
@@ -75,7 +74,6 @@
                         height: 100%;
                         vertical-align: bottom;
                       }
-
                     }
                     .slick-active{
                       opacity: 1;
@@ -83,36 +81,6 @@
                 }
               }
             }
-
-
-            // .owl-dots{
-            //     line-height: 0;
-            //     margin: 0;
-            //     cursor: default;
-            //     max-height: none;
-            //     font-size: 0;
-            //     .owl-dot{
-            //       width: 75px;
-            //       height: 75px;
-            //       position: relative;
-            //       overflow: hidden;
-            //       display: inline-block;
-            //       line-height: 0;
-
-            //       .owl-dot-inner{
-            //         line-height: 0;
-            //         position: static;
-            //         width: auto;
-            //         height: 75px;
-            //         padding: 0;
-            //         img{
-            //           width: 100%;
-            //           height: 100%;
-            //           vertical-align: bottom;
-            //         }
-            //       }
-            //     }
-            //   }
           }
           .item-sold-out-badge{
             div{
@@ -151,14 +119,10 @@
         vertical-align: middle;
         border-color: inherit;
         border: 1px solid #f5f5f5;
-
-
         tbody{
           vertical-align: middle;
           border-color: inherit;
           font-size: 14px;
-
-
           tr{
             display: table-row;
             vertical-align: inherit;
@@ -202,7 +166,6 @@
                   color: #6ab5d8;
                   }
                 }
-
               }
             }
           }
@@ -262,9 +225,7 @@
           border-radius: 40px;
           .fa-heart{
             color: #ccc;
-
           }
-
         }
         .item-button-liked {
           color: #333;
@@ -300,11 +261,7 @@
         }
       }
     }
-    // ポイント関係
-
 }
-
-// 消去機能
 
 .listing-item-change-box{
   margin: 24px auto;
@@ -461,7 +418,6 @@
   width: 700px;
   margin: 8px auto;
   .message-container{
-
     .message-content{
       padding: 24px;
       background: #fff;
@@ -574,19 +530,6 @@
                 }
               }
             }
-            // .icon-balloon{
-            //   position: absolute;
-            //   top: 8px;
-            //   left: -20px;
-            //   color: #eef0f4;
-            //   display: inline-block;
-            //   font-family: 'icon-font';
-            //   font-size: 15px;
-            //   &:before{
-            //     // 保留
-              // }
-            // }
-
           }
         }
         .clearfix:after {
@@ -632,4 +575,120 @@
   }
 }
 
-
+.items-container{
+  margin: 0 auto;
+  padding-bottom: 20px;
+  &-head{
+    font-size: 22px;
+    margin: 24px 4% 8px;
+    line-height: 1.4;
+    p{
+      color: #0099e8;
+    }
+  }
+  &-content.clearfix{
+        width: auto;
+        margin: 0 auto;
+        height: 330px;
+        .items-box{
+          margin: 0 10px 20px 10px;
+          width: 213px;
+          background-color: blue;
+          float: left;
+          background: #fff;
+          position: relative;
+          a{
+            display: block;
+            color: #333;
+            text-decoration: none;
+            .items-box-photo {
+              &-badge{
+              div{
+                background-color: red;
+                position: absolute;
+                left: 0;
+                z-index: 2;
+                color: #fff;
+                transform: rotate(-45deg);
+                letter-spacing: 2px;
+                font-weight: 600;
+                top: 24px;
+                font-size: 28px;
+              }
+            }
+            &-badge:after{
+              border-width: 120px 120px 0 0;
+              border-color: #ea352d transparent transparent transparent;
+              display: block;
+              content: ‘’;
+              position: absolute;
+              top: 0;
+              left: 0;
+              z-index: 1;
+              width: 0;
+              height: 0;
+              border-style: solid;
+            }
+              width: 213px;
+              overflow: hidden;
+              position: relative;
+              padding: 0 0 100%;
+              margin: 0;
+              .is-higher-height.lazyloaded{
+                position: absolute;
+                z-index: 1;
+                width: 100%;
+                height: 100%;
+              }
+            }
+            .items-box-body{
+              padding: 16px 16px 8px 16px;
+              .items-box-name{
+                overflow: hidden;
+                position: relative;
+                font-weight: 400;
+                height: 3em;
+                line-height: 1.5;
+                word-break: break-word;
+                white-space: normal;
+                font-size: 16px;
+                color: #333;
+              }
+              .items-box-num.clearfix{
+                margin: 8px 0 0;
+                .items-box-price{
+                  font-size: 19px;
+                  float: left;
+                  font-weight: 600;
+                  color: #333;
+                }
+                .items-box-likes{
+                  float: right;
+                  font-size: 16px;
+                  vertical-align: middle;
+                  .fa-heart{
+                  display: inline-block;
+                  speak: none;
+                  font-style: normal;
+                  font-weight: 400;
+                  font-variant: normal;
+                  text-transform: none;
+                  line-height: 1;
+                  color: #ccc;
+                  vertical-align: inherit;
+                  }
+                  span{
+                    display: inline-block;
+                    vertical-align: middle;
+                  }
+                }
+                .item-box-tax{
+                  font-size: 10px;
+                  clear: both;
+                }
+              }
+            }
+          }
+        }
+      }
+    }

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -26,7 +26,7 @@ class ProductsController < ApplicationController
   def show
     @product = Product.find(params[:id])
     @seller = User.find_by(id: @product.seller)
-    @another_product = @seller.products.where(seller: @seller.id).where.not(id: @product.id)
+    @another_product = @seller.products.where.not(id: @product.id)
     @comment = Comment.new
     @comments = Comment.where(product_id: @product.id)
   end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -26,7 +26,7 @@ class ProductsController < ApplicationController
   def show
     @product = Product.find(params[:id])
     @seller = User.find_by(id: @product.seller)
-    @another_product = Product.where(seller: @seller.id).where.not(id: @product.id)
+    @another_product = @seller.products.where(seller: @seller.id).where.not(id: @product.id)
     @comment = Comment.new
     @comments = Comment.where(product_id: @product.id)
   end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -25,6 +25,8 @@ class ProductsController < ApplicationController
 
   def show
     @product = Product.find(params[:id])
+    @seller = User.find_by(id: @product.seller)
+    @another_product = Product.where(seller: @seller.id).where.not(id: @product.id)
     @comment = Comment.new
     @comments = Comment.where(product_id: @product.id)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,:omniauthable,:omniauth_providers => [:facebook,:google_oauth2]
   validates :name, presence: true
-  has_many :products
+  has_many :products, foreign_key: :seller
   has_one :address,dependent: :destroy
   accepts_nested_attributes_for :address
   has_many :trades

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -103,7 +103,7 @@
       (税込)
     %span.item-shipping-fee
       送料込み
-  - if @product.trade.deal == false && @product.seller != current_user.id && @product.trade.user_id.nil?
+  - if @product.trade.deal == false && @product.trade.user_id.nil?
     = link_to product_mypayjp_path(@product), class: "item-buy-btn" do
       商品を購入する
   - else
@@ -195,3 +195,10 @@
         = f.text_area :text,class: "textarea-default"
         = f.button type: "submit",class: "message-submit" do
           %spam コメントする
+  .items-container
+    %h2.items-container-head
+      %p
+        = "#{@seller.name} さんの他の出品"
+    .items-container-content.clearfix
+      = render partial: "productlist", collection: @another_product, as: :product
+= render "products/footer"


### PR DESCRIPTION
# What
ユーザーが商品詳細ページを閲覧した際、ページの下部にその出品者が他に出品している商品を一覧で表示できるように実装。
閲覧している商品自体は一覧から除外するようにコントローラー側で記載。

以下、Gifです。

[![Image from Gyazo](https://i.gyazo.com/06e97a5a37fcff7807ad1d7a75b2569c.gif)](https://gyazo.com/06e97a5a37fcff7807ad1d7a75b2569c)

# Why
ユーザーが他の商品を閲覧する確率をあげ、購買に繋げるため。