### PR TITLE
Show same category product to show.html.haml

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -27,6 +27,8 @@ class ProductsController < ApplicationController
     @product = Product.find(params[:id])
     @seller = User.find_by(id: @product.seller)
     @another_product = @seller.products.where.not(id: @product.id)
+    @same_category = @product.category
+    @same_category_products = @same_category.products.where.not(id: @product.id)
     @comment = Comment.new
     @comments = Comment.where(product_id: @product.id)
   end

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -195,10 +195,18 @@
         = f.text_area :text,class: "textarea-default"
         = f.button type: "submit",class: "message-submit" do
           %spam コメントする
-  .items-container
-    %h2.items-container-head
-      %p
-        = "#{@seller.name} さんの他の出品"
-    .items-container-content.clearfix
-      = render partial: "productlist", collection: @another_product, as: :product
+  - if @another_product
+    .items-container
+      %h2.items-container-head
+        %p
+          = "#{@seller.name} さんの他の出品"
+      .items-container-content.clearfix
+        = render partial: "productlist", collection: @another_product, as: :product
+  - if @same_category_products
+    .items-container
+      %h2.items-container-head
+        %p
+          同じカテゴリーの商品
+      .items-container-content.clearfix
+        = render partial: "productlist", collection: @same_category_products, as: :product
 = render "products/footer"


### PR DESCRIPTION
# What
商品詳細ページに、カテゴリが親カテゴリから全く同じ商品表示させる。

# Why
ユーザーが商品を探しているとき、閲覧してる商品と同じカテゴリの商品は購入される確率が高いため。
ソートしているカテゴリの粒度は一番細い粒度で、その理由はその上のカテゴリで説別などでカテゴリが分けられており、ユーザーの目的と異なる商品が表示されるのを防ぐため。
ex) 女の子用を探しているのに男の子用がでるなど。

# 挙動
以下では、商品名no2 と no4が 同じカテゴリに属している。
[![Image from Gyazo](https://i.gyazo.com/59a08d410991f98863ad142f9dcab199.gif)](https://gyazo.com/59a08d410991f98863ad142f9dcab199)