### PR TITLE
部分テンプレートfooter 修正

### DIFF
--- a/app/views/addresses/new.html.haml
+++ b/app/views/addresses/new.html.haml
@@ -72,16 +72,4 @@
                 =f.number_field :telephone, class: 'input-default', placeholder:'例）09012345678', value: ""
             = f.button html: {class: "btn-default btn-red", type: "submit"} do
               次へ進む
-    %footer.single-footer
-      %nav
-        %ul.clearfix
-          %li
-            %a{href: "https://www.mercari.com/jp/privacy/"} プライバシーポリシー
-          %li
-            %a{href: "https://www.mercari.com/jp/tos/"} メルカリ利用規約
-          %li
-            %a{href: "https://www.mercari.com/jp/tokutei/"} 特定商取引に関する表記
-      %a.single-footer-logo{href: "https://www.mercari.com/jp/"}
-        %img{alt: "mercari", height: "65", src: "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?327793976", width: "80"}/
-      %p
-        %small © 2019 Mercari
+  = render "users/footer"

--- a/app/views/devise/registrations/new_phoneno.html.haml
+++ b/app/views/devise/registrations/new_phoneno.html.haml
@@ -51,4 +51,4 @@
               を確認して、もう一度電話番号を入力してください。
 
     %footer
-      = render "products/header_logo"
+      = render "users/footer"

--- a/app/views/devise/registrations/new_phoneno.html.haml
+++ b/app/views/devise/registrations/new_phoneno.html.haml
@@ -50,5 +50,4 @@
               %a{:href => "", :target => "_blank"}> SMS受信設定
               を確認して、もう一度電話番号を入力してください。
 
-    %footer
-      = render "users/footer"
+    = render "users/footer"

--- a/app/views/users/_footer.html.haml
+++ b/app/views/users/_footer.html.haml
@@ -2,12 +2,15 @@
   %nav
     %ul.clearfix
       %li
-        %a{href: ""} プライバシーポリシー
+        = link_to "#" do
+          プライバシーポリシー
       %li
-        %a{href: ""} メルカリ利用規約
+        = link_to "#" do
+          メルカリ利用規約
       %li
-        %a{href: ""} 特定商取引に関する表記
-  %a.single-footer-logo{href: ""}
-    %img{alt: "mercari", src: "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?4136293187"}/
+        = link_to "#" do
+          特定商取引に関する表記
+  = link_to root_path, class: "single-footer-logo" do
+    = image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?4136293187", alt:"mercari"
   %p
     %small © 2019 Mercari


### PR DESCRIPTION
#WHAT
・部分テンプレートにしたfooterをlink_toにて修正いたしました。
・合わせて、部分テンプレートを使用できていなかったhtmlと、誤った部分テンプレートを使用していたhtmlを修正いたしました。

#WHY
・可読性を高めるため。
・記述を少なくし、綺麗なコードにするため。