### PR TITLE
商品出品・編集時のフラッシュメッセージの変更

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -43,9 +43,9 @@ class ProductsController < ApplicationController
 
     if @product.save
       Trade.create(product_id: @product.id)
-      redirect_to root_path(@product), notice: "出品が完了しました"
+      redirect_to root_path(@product), flash: {success: "出品が完了しました"}
     else
-      redirect_to new_product_path, alert: "必須項目をすべて選択してください"
+      redirect_to new_product_path, flash: {miss: "必須項目をすべて選択してください"}
     end
   end
 

--- a/app/views/products/_header.html.haml
+++ b/app/views/products/_header.html.haml
@@ -1,6 +1,6 @@
-- if flash[:notice]
+- if flash[:success]
   %p#flash.flash-notice
-    = flash[:notice]
+    = flash[:success]
 %header.pc-header.visible-pc
   .pc-header-inner
     .clearfix

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -1,6 +1,6 @@
-- if flash[:alert]
+- if flash[:miss]
   %p#flash.flash-alert
-    = flash[:alert]
+    = flash[:miss]
 .single-container{style: 'padding: 0;'}
   = render "users/header.html.haml"
 %main.single-main

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -1,6 +1,6 @@
-- if flash[:alert]
+- if flash[:miss]
   %p#flash.flash-alert
-    = flash[:alert]
+    = flash[:miss]
 .single-container{style: 'padding: 0;'}
   = render "users/header.html.haml"
 %main.single-main


### PR DESCRIPTION
# WHAT
フラッシュメッセージのキー名を変更。

# WHY
Deviseのflashメッセージとキーがかぶっており、ログイン・ログアウト時も意図しないflashメッセージが表示されてしまっていたため。