### PR TITLE
フラグメントキャッシュの利用

### DIFF
--- a/app/views/products/_header.html.haml
+++ b/app/views/products/_header.html.haml
@@ -26,13 +26,14 @@
                   %ul.pc-header-nav-child-wrap
                     - root.children.first(14).each do |child|
                       %li.pc-header-nav-child
-                        = link_to category_path(id: child.id) do
-                          = child.name
-                        %ul.pc-header-nav-grand-child-wrap
-                          - child.children.first(14).each do |son|
-                            %li.pc-header-nav-grand-child
-                              = link_to category_path(id: son.id) do
-                                = son.name
+                        - cache child do
+                          = link_to category_path(id: child.id) do
+                            = child.name
+                          %ul.pc-header-nav-grand-child-wrap
+                            - child.children.first(14).each do |son|
+                              %li.pc-header-nav-grand-child
+                                = link_to category_path(id: son.id) do
+                                  = son.name
               %li.pc-header-nav-parent
                 %h3
                   = link_to category_index_path do

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -58,12 +58,13 @@
                       %i.fas.fa-chevron-down
                   - @categoryroot.each do |root|
                     .select-box-list
-                      = collection_select :product, :category_id, root.children, :id, :name,{include_blank: "---"}, {class: "select-default select-box-child",child_id: "#{root.id}"}
-                      %i.fas.fa-chevron-down
-                    - root.children.each do |son|
-                      .select-box-list-son
-                        = f.collection_select :category_id, son.children, :id, :name, {include_blank: "---"}, {class: "select-default select-box-son", son_id: "#{son.id}"}
+                      - cache root.children do
+                        = collection_select :product, :category_id, root.children, :id, :name,{include_blank: "---"}, {class: "select-default select-box-child",child_id: "#{root.id}"}
                         %i.fas.fa-chevron-down
+                        - root.children.each do |son|
+                          .select-box-list-son
+                            = f.collection_select :category_id, son.children, :id, :name, {include_blank: "---"}, {class: "select-default select-box-son", son_id: "#{son.id}"}
+                            %i.fas.fa-chevron-down
                   = f.hidden_field :category_id, {class: "category"}
                 .form-group
                   = f.label :size_id do


### PR DESCRIPTION
# WHAT
フラグメントキャッシュを利用して表示のスピードを早くした。
# WHY
ページの読み込みに多くの時間がかかっており、ユーザーのストレスになる可能性があったので、ページ遷移にかかる時間を減らし、ストレスを排除するため。